### PR TITLE
Removing redirect to non-existent error pages

### DIFF
--- a/files/etc/nginx/sites-enabled/site.conf
+++ b/files/etc/nginx/sites-enabled/site.conf
@@ -45,15 +45,6 @@ server {
         try_files $uri $uri/ /index.php?q=$uri&$args;
     }
 
-    #error_page 404 /404.html;
-
-    # redirect server error pages to the static page /50x.html
-    #
-    error_page 500 502 503 504 /50x.html;
-    location = /50x.html {
-        root /usr/share/nginx/html;
-    }
-
     location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
         expires 30d;
     }


### PR DESCRIPTION
Neither this image, nor any of the parent images, contain HTML for error pages in the directory specified. The result is that a 404 is generated for all errors (referring to the fact that the error page can't be found). 

This change removes the directives instructing nginx to use static error page HTML.

Jira GPHMCH-28, DHSERVER-8298, FHITOPS-220.